### PR TITLE
Fix Pixbuf deprecation warning

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -141,7 +141,7 @@ public class MainWindow : ApplicationWindow {
             var stream = new BufferedInputStream(
                 yield req.send_async(null)
             );
-            Gdk.Pixbuf pixbuf = yield Gdk.Pixbuf.new_from_stream_at_scale_async (stream, 220, -1, true);
+            Gdk.Pixbuf pixbuf = yield new Gdk.Pixbuf.from_stream_at_scale_async (stream, 220, -1, true);
             this.image.set_from_pixbuf (pixbuf);
             this.copy_source.sensitive = true;
         }catch(Error error){


### PR DESCRIPTION
There was a deprecation warning with `Gdk.Pixbuf` when compiling so here is the fix.